### PR TITLE
support sourceFinder

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,12 +14,14 @@ exports = module.exports = {
       includeDir: './',
       reportDir: './coverage',
       reporter: ['text'],
+      sourceFinder: null,
     }, config);
     this.coverageMap = libCoverage.createCoverageMap();
   },
   teardown() {
     const context = libReport.createContext({
       dir: this.coverageOpts.reportDir,
+      sourceFinder: this.coverageOpts.sourceFinder,
     });
     const tree = libReport.summarizers.pkg(this.coverageMap);
     this.coverageOpts.reporter.forEach((report) => {


### PR DESCRIPTION
Support sourceFinder of istanbul-lib-report to lookup file from different location.

e.g. protractor run on a docker container, and web server is located on another docker container.

[sourceFinder]: https://github.com/istanbuljs/istanbuljs/blob/0f328fd0896417ccb2085f4b7888dd8e167ba3fa/packages/istanbul-lib-report/lib/context.js#L32-L53