### PR TITLE
add saveCoverageMap option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
+const fs = require('fs');
 const path = require('path');
+const _ = require('lodash-core');
 const libCoverage = require('istanbul-lib-coverage');
 const libReport = require('istanbul-lib-report');
 const reports = require('istanbul-reports');
@@ -10,12 +12,25 @@ exports = module.exports = {
       delete config[name];
     });
 
-    this.coverageOpts = Object.assign({
+    const defaultConfig = {
       includeDir: './',
       reportDir: './coverage',
       reporter: ['text'],
-    }, config);
-    this.coverageMap = libCoverage.createCoverageMap();
+      saveCoverageMap: {
+        enabled: false,
+        path: './.localCoverageMap',
+      },
+    };
+
+    this.coverageOpts = _.merge(defaultConfig, config);
+
+    if (this.coverageOpts.saveCoverageMap.enabled && fs.existsSync(this.coverageOpts.saveCoverageMap.path)) {
+      console.log("loading coverageMap from %s ...", this.coverageOpts.saveCoverageMap.path);
+      const convMap = fs.readFileSync(this.coverageOpts.saveCoverageMap.path, 'utf8');
+      this.coverageMap = libCoverage.createCoverageMap(JSON.parse(convMap));
+    } else {
+      this.coverageMap = libCoverage.createCoverageMap();
+    }
   },
   teardown() {
     const context = libReport.createContext({
@@ -25,6 +40,10 @@ exports = module.exports = {
     this.coverageOpts.reporter.forEach((report) => {
       tree.visit(reports.create(report), context);
     });
+    if (this.coverageOpts.saveCoverageMap.enabled) {
+      console.log("saving coverageMap to %s ...", this.coverageOpts.saveCoverageMap.path);
+      fs.writeFileSync(this.coverageOpts.saveCoverageMap.path, JSON.stringify(this.coverageMap, 'utf8'));
+    }
   },
   async postTest() {
     const coverage = await browser.executeScript('return typeof __coverage__ === "undefined" ? {} : __coverage__;');

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "ofk",
   "license": "MIT",
   "dependencies": {
+    "lodash-core": "^4.17.15",
     "istanbul-lib-coverage": "^1.1.2",
     "istanbul-lib-report": "^1.1.3",
     "istanbul-reports": "^1.1.4"


### PR DESCRIPTION
This option support to save coverageMap to local filesystem.

In my use-case, protractor runs multiple times, and I'd like to merge coverageMap for generating a coverage report. I'm not sure this is useful for general users.

Note that this doesn't remove stored coverageMap, so a user have to remove it before starting tests. In my case, the file is only stored docker container, so I don't remove it manually...